### PR TITLE
feat: build site in the shuttle builder

### DIFF
--- a/Shuttle.toml
+++ b/Shuttle.toml
@@ -1,3 +1,3 @@
 build_assets = [
-  "static",
+  "public",
 ]

--- a/shuttle_postbuild.sh
+++ b/shuttle_postbuild.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# Download and extract the trunk binary
+curl -L https://github.com/trunk-rs/trunk/releases/download/v0.21.0-rc.3/trunk-x86_64-unknown-linux-gnu.tar.gz -o trunk.tar.gz
+tar -xzf trunk.tar.gz
+
+# Clean up the tar file
+rm trunk.tar.gz
+
+# Run trunk build
+cd /app/site && /app/trunk clean && /app/trunk build --release

--- a/site/Trunk.toml
+++ b/site/Trunk.toml
@@ -2,4 +2,4 @@
 
 [build]
 
-dist = "../static"
+dist = "../public"


### PR DESCRIPTION
Download the trunk binary from their binary distributions, use that to build the static site, and list it (public) in the build_assets so it's available to the application at runtime.